### PR TITLE
Minor Xcode maintenance

### DIFF
--- a/Colloquy (Old).xcodeproj/project.pbxproj
+++ b/Colloquy (Old).xcodeproj/project.pbxproj
@@ -885,7 +885,7 @@
 		C21296FF1F6465FC00555EE3 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		C23298971C3D98230085CBF7 /* NSWindow+CQMCoordinateSpaceConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSWindow+CQMCoordinateSpaceConversion.h"; path = "Additions/NSWindow+CQMCoordinateSpaceConversion.h"; sourceTree = "<group>"; };
 		C23298981C3D98230085CBF7 /* NSWindow+CQMCoordinateSpaceConversion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSWindow+CQMCoordinateSpaceConversion.m"; path = "Additions/NSWindow+CQMCoordinateSpaceConversion.m"; sourceTree = "<group>"; };
-		C236F6561BDCE81200E64469 /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = Importer/English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		C236F6561BDCE81200E64469 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = Importer/English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C236F6591BDCE81F00E64469 /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = Importer/English.lproj/schema.strings; sourceTree = "<group>"; };
 		C237FEC91CA2EA9B00CB8C69 /* autoHeader.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; name = autoHeader.pdf; path = Resources/autoHeader.pdf; sourceTree = "<group>"; };
 		C237FECB1CA2EFD600CB8C69 /* smartTranscript.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; name = smartTranscript.pdf; path = Resources/smartTranscript.pdf; sourceTree = "<group>"; };

--- a/Importer/English.lproj/InfoPlist.strings
+++ b/Importer/English.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 /* Localized versions of Info.plist keys */
 
-CFBundleGetInfoString = "Colloquy Metadata Importer 1.0; Copyright © 2005, Karl Adam";
-NSHumanReadableCopyright = "Copyright © 2005, Karl Adam";
+CFBundleGetInfoString = "Colloquy Metadata Importer 1.0; Copyright Â© 2005, Karl Adam";
+NSHumanReadableCopyright = "Copyright Â© 2005, Karl Adam";


### PR DESCRIPTION
Changes the encoding of the Metadata's InfoPlist.Strings file to UTF-8.