### PR TITLE
Update nibs

### DIFF
--- a/Languages/de.lproj/JVBuddyInspector.xib
+++ b/Languages/de.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" imageHugsTitle="YES" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" imageHugsTitle="YES" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>
@@ -421,7 +421,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="8Qn-Cb-OSY">
                             <rect key="frame" x="1" y="1" width="198" height="97"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="284">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="97"/>
@@ -463,7 +463,7 @@
                     <button toolTip="Add domain" imageHugsTitle="YES" id="287">
                         <rect key="frame" x="72" y="40" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" enabled="NO" inset="2" id="361">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="361">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                             <string key="keyEquivalent">+</string>
@@ -476,7 +476,7 @@
                     <button toolTip="Delete domain" imageHugsTitle="YES" id="289">
                         <rect key="frame" x="72" y="64" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="362">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="362">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -518,10 +518,8 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
     </resources>

--- a/Languages/de.lproj/JVConnectionInspector.xib
+++ b/Languages/de.lproj/JVConnectionInspector.xib
@@ -452,7 +452,7 @@ betreten:</string>
                                     <button id="181">
                                         <rect key="frame" x="63" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -464,7 +464,7 @@ betreten:</string>
                                     <button id="182">
                                         <rect key="frame" x="63" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="450">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="450">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -479,7 +479,7 @@ betreten:</string>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="RqM-5Y-0SG">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -531,7 +531,7 @@ betreten:</string>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="P5a-JR-s5w">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -588,7 +588,7 @@ betreten:</string>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="o6B-se-SUr">
                                             <rect key="frame" x="1" y="1" width="288" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="288" height="246"/>
@@ -641,7 +641,7 @@ betreten:</string>
                                     <button toolTip="Ignorier-Regel hinzufügen" id="404">
                                         <rect key="frame" x="235" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="453">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -663,7 +663,7 @@ betreten:</string>
                                     <button toolTip="Ignorier-Regel löschen" id="406">
                                         <rect key="frame" x="261" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="455">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/de.lproj/JVConnectionInspector.xib
+++ b/Languages/de.lproj/JVConnectionInspector.xib
@@ -686,7 +686,7 @@ betreten:</string>
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="314" height="282"/>
+                <rect key="frame" x="0.0" y="0.0" width="314" height="282"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -694,7 +694,7 @@ betreten:</string>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="P2M-qS-A6a">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -766,7 +766,7 @@ betreten:</string>
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="456">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="456">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -779,7 +779,7 @@ betreten:</string>
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="465">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -932,11 +932,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/de.lproj/JVFind.xib
+++ b/Languages/de.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/de.lproj/JVFind.xib
+++ b/Languages/de.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/de.lproj/JVRoomInspector.xib
+++ b/Languages/de.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="Banns" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="OXc-L4-Y5N">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="283" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="Bann hinzufügen" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="Bann löschen" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -476,10 +476,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/de.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/de.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/de.lproj/MVBuddyList.xib
+++ b/Languages/de.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="Kotakt hinzufügen" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="Action" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/de.lproj/MVConnections.xib
+++ b/Languages/de.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="vMu-o3-MJv">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="873" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -178,7 +178,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="402" height="419"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView autoresizesSubviews="NO" drawsBackground="NO" type="noTabsNoBorder" id="658">
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" id="658">
                         <rect key="frame" x="0.0" y="46" width="402" height="242"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="402" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="402" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="162" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="gxq-Mo-mAF">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="135" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="135" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="817">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="817">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1076,9 +1076,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:808:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1162,7 +1162,5 @@ ETAROBE7EUARTxFTEVoRYhFvEXQRdhF4EX0RhRGIEY0RlRGYEaoRrRGyAAAAAAAAAgEAAAAAAAAAQQAA
 AAAAAAAAAAAAAAAAEbQ
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/en.lproj/JVBuddyInspector.xib
+++ b/Languages/en.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>

--- a/Languages/en.lproj/JVConnectionInspector.xib
+++ b/Languages/en.lproj/JVConnectionInspector.xib
@@ -684,7 +684,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="314" height="282"/>
+                <rect key="frame" x="0.0" y="0.0" width="314" height="282"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="95b-xS-uzp">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="456">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="456">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="465">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -930,11 +930,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/en.lproj/JVConnectionInspector.xib
+++ b/Languages/en.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="63" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="63" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="450">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="450">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="72X-bY-2Id">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="ZcQ-nq-VMp">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="QWv-QS-7rk">
                                             <rect key="frame" x="1" y="1" width="288" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="288" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Add ignore" id="404">
                                         <rect key="frame" x="239" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="453">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Delete ignore" id="406">
                                         <rect key="frame" x="261" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="455">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/en.lproj/JVFind.xib
+++ b/Languages/en.lproj/JVFind.xib
@@ -74,9 +74,9 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="245">
-                                                <behavior key="behavior" lightByContents="YES"/>
-                                                <font key="font" metaFont="titleBar" size="12"/>
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
                                                 <connections>
                                                     <action selector="removeRow:" target="-2" id="392"/>
                                                 </connections>
@@ -88,7 +88,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="titleBar" size="12"/>
                                                 <connections>

--- a/Languages/en.lproj/JVRoomInspector.xib
+++ b/Languages/en.lproj/JVRoomInspector.xib
@@ -259,7 +259,7 @@ DQ
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="WZp-Cq-9Z4">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="286" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="Add ban" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="Delete ban" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/en.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/en.lproj/JVSmartTranscriptFilterSheet.xib
@@ -61,7 +61,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -198,6 +198,5 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/en.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/en.lproj/JVSmartTranscriptFilterSheet.xib
@@ -61,7 +61,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -75,7 +75,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>

--- a/Languages/en.lproj/MVBuddyList.xib
+++ b/Languages/en.lproj/MVBuddyList.xib
@@ -109,7 +109,7 @@
                     <button toolTip="Add buddy" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -142,7 +142,7 @@
                     <button toolTip="Action" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>

--- a/Languages/en.lproj/MVConnections.xib
+++ b/Languages/en.lproj/MVConnections.xib
@@ -66,7 +66,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="oTu-bd-Lr7">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="100869" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -185,7 +185,7 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="351" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
@@ -198,7 +198,7 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="dOT-UR-0ZI">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -282,7 +282,7 @@
                                         <button id="667">
                                             <rect key="frame" x="105" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="100809">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="100809">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -324,7 +324,7 @@
                                         <button id="672">
                                             <rect key="frame" x="105" y="28" width="19" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" inset="2" id="100813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="100813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
                                                 <string key="keyEquivalent"></string>

--- a/Languages/es.lproj/JVBuddyInspector.xib
+++ b/Languages/es.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>

--- a/Languages/es.lproj/JVConnectionInspector.xib
+++ b/Languages/es.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="74" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="448">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="448">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="74" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="4SA-4F-3IQ">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="gJl-KS-ZtB">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="uWg-8D-c7N">
                                             <rect key="frame" x="1" y="1" width="288" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="288" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Add ignore" id="403">
                                         <rect key="frame" x="246" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="452">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="452">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Delete ignore" id="405">
                                         <rect key="frame" x="272" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="454">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="454">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/es.lproj/JVConnectionInspector.xib
+++ b/Languages/es.lproj/JVConnectionInspector.xib
@@ -684,7 +684,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="324" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="324" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="fBJ-0F-MO8">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="455">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="464">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="464">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -930,11 +930,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/es.lproj/JVFind.xib
+++ b/Languages/es.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/es.lproj/JVFind.xib
+++ b/Languages/es.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/es.lproj/JVRoomInspector.xib
+++ b/Languages/es.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="Bans" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="dRP-IN-R1d">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="283" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="Add ban" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="Delete ban" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -476,10 +476,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/es.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/es.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/es.lproj/MVBuddyList.xib
+++ b/Languages/es.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="Añadir amigo" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="Action" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/es.lproj/MVConnections.xib
+++ b/Languages/es.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="dT2-RL-SX9">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="873" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -178,7 +178,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="402" height="419"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView autoresizesSubviews="NO" drawsBackground="NO" type="noTabsNoBorder" id="658">
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" id="658">
                         <rect key="frame" x="-8" y="46" width="420" height="242"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="420" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="420" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="199" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="iQr-oh-Z8K">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="172" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="172" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="817">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="817">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1076,9 +1076,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:808:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1162,7 +1162,5 @@ ETAROBE7EUARTxFTEVoRYhFvEXQRdhF4EX0RhRGIEY0RlRGYEaoRrRGyAAAAAAAAAgEAAAAAAAAAQQAA
 AAAAAAAAAAAAAAAAEbQ
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/fr.lproj/JVBuddyInspector.xib
+++ b/Languages/fr.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" imageHugsTitle="YES" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" imageHugsTitle="YES" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>
@@ -294,7 +294,7 @@
             <rect key="contentRect" x="267" y="404" width="318" height="300"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" autoresizesSubviews="NO" id="215">
-                <rect key="frame" x="1" y="1" width="318" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="318" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" id="249">
@@ -421,7 +421,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="aBo-TO-oxa">
                             <rect key="frame" x="1" y="1" width="198" height="97"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="284">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="97"/>
@@ -463,7 +463,7 @@
                     <button toolTip="Add domain" imageHugsTitle="YES" id="287">
                         <rect key="frame" x="72" y="40" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" enabled="NO" inset="2" id="361">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="361">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                             <string key="keyEquivalent">+</string>
@@ -476,7 +476,7 @@
                     <button toolTip="Delete domain" imageHugsTitle="YES" id="289">
                         <rect key="frame" x="72" y="64" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="362">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="362">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -518,10 +518,8 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
     </resources>

--- a/Languages/fr.lproj/JVConnectionInspector.xib
+++ b/Languages/fr.lproj/JVConnectionInspector.xib
@@ -684,7 +684,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="344" height="282"/>
+                <rect key="frame" x="0.0" y="0.0" width="344" height="282"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="Fjg-si-tsn">
                             <rect key="frame" x="1" y="1" width="284" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="284" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="456">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="456">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="465">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -930,11 +930,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/fr.lproj/JVConnectionInspector.xib
+++ b/Languages/fr.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="115" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="115" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="450">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="450">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="RvD-Ow-cCs">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="Awv-3i-sD8">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="dSB-Hn-jXI">
                                             <rect key="frame" x="1" y="1" width="288" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="288" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Add ignore" id="404">
                                         <rect key="frame" x="261" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="453">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Delete ignore" id="406">
                                         <rect key="frame" x="287" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="455">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/fr.lproj/JVFind.xib
+++ b/Languages/fr.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/fr.lproj/JVFind.xib
+++ b/Languages/fr.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/fr.lproj/JVRoomInspector.xib
+++ b/Languages/fr.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="Bans" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="1ND-Uy-Adh">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="286" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="Add ban" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="Delete ban" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -476,10 +476,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/fr.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/fr.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/fr.lproj/MVBuddyList.xib
+++ b/Languages/fr.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="Ajouter une personne" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="Action" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/fr.lproj/MVConnections.xib
+++ b/Languages/fr.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="ozu-Iy-Rbn">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="873" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -178,7 +178,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="372" height="419"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView autoresizesSubviews="NO" drawsBackground="NO" type="noTabsNoBorder" id="658">
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" id="658">
                         <rect key="frame" x="-11" y="46" width="382" height="242"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="382" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="382" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="163" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="CdM-Jm-FeE">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="136" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="136" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="817">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="817">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1076,9 +1076,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:808:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1162,7 +1162,5 @@ ETAROBE7EUARTxFTEVoRYhFvEXQRdhF4EX0RhRGIEY0RlRGYEaoRrRGyAAAAAAAAAgEAAAAAAAAAQQAA
 AAAAAAAAAAAAAAAAEbQ
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/it.lproj/JVBuddyInspector.xib
+++ b/Languages/it.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" imageHugsTitle="YES" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" imageHugsTitle="YES" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>
@@ -294,7 +294,7 @@
             <rect key="contentRect" x="267" y="404" width="318" height="300"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" autoresizesSubviews="NO" id="215">
-                <rect key="frame" x="1" y="1" width="318" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="318" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" id="249">
@@ -421,7 +421,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="RCv-Pb-hIs">
                             <rect key="frame" x="1" y="1" width="198" height="97"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="284">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="97"/>
@@ -463,7 +463,7 @@
                     <button toolTip="Add domain" imageHugsTitle="YES" id="287">
                         <rect key="frame" x="72" y="40" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" enabled="NO" inset="2" id="361">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="361">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                             <string key="keyEquivalent">+</string>
@@ -476,7 +476,7 @@
                     <button toolTip="Delete domain" imageHugsTitle="YES" id="289">
                         <rect key="frame" x="72" y="64" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="362">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="362">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -518,10 +518,8 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
     </resources>

--- a/Languages/it.lproj/JVConnectionInspector.xib
+++ b/Languages/it.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="84" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="448">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="448">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="84" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="IxT-PJ-iXo">
                                             <rect key="frame" x="1" y="1" width="247" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="247" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="gmM-XO-J7d">
                                             <rect key="frame" x="1" y="1" width="247" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="247" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="BiT-gb-ZSH">
                                             <rect key="frame" x="1" y="1" width="312" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="312" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Aggiungi ignore" id="403">
                                         <rect key="frame" x="280" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="452">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="452">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Rimuovi ignore" id="405">
                                         <rect key="frame" x="306" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="454">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="454">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/it.lproj/JVConnectionInspector.xib
+++ b/Languages/it.lproj/JVConnectionInspector.xib
@@ -59,11 +59,11 @@
                     <tabViewItems>
                         <tabViewItem label="Generale" identifier="General" id="139">
                             <view key="view" id="136">
-                                <rect key="frame" x="10" y="25" width="395" height="298"/>
+                                <rect key="frame" x="10" y="29" width="395" height="294"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <textField verticalHuggingPriority="750" id="140">
-                                        <rect key="frame" x="86" y="123" width="61" height="14"/>
+                                        <rect key="frame" x="86" y="119" width="61" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="427">
                                             <font key="font" metaFont="smallSystem"/>
@@ -72,7 +72,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" id="141">
-                                        <rect key="frame" x="152" y="121" width="205" height="19"/>
+                                        <rect key="frame" x="152" y="117" width="205" height="19"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <secureTextFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="428">
                                             <font key="font" metaFont="smallSystem"/>
@@ -88,7 +88,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" id="142">
-                                        <rect key="frame" x="58" y="150" width="89" height="14"/>
+                                        <rect key="frame" x="58" y="146" width="89" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Soprannome:" id="429">
                                             <font key="font" metaFont="smallSystem"/>
@@ -97,7 +97,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="143">
-                                        <rect key="frame" x="152" y="148" width="205" height="19"/>
+                                        <rect key="frame" x="152" y="144" width="205" height="19"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="430">
                                             <font key="font" metaFont="smallSystem"/>
@@ -111,7 +111,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="145">
-                                        <rect key="frame" x="38" y="266" width="109" height="14"/>
+                                        <rect key="frame" x="38" y="262" width="109" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Server:" id="431">
                                             <font key="font" metaFont="smallSystem"/>
@@ -120,7 +120,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <comboBox verticalHuggingPriority="750" id="146">
-                                        <rect key="frame" x="152" y="262" width="208" height="22"/>
+                                        <rect key="frame" x="152" y="258" width="208" height="22"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <comboBoxCell key="cell" controlSize="small" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" drawsBackground="YES" usesDataSource="YES" numberOfVisibleItems="10" id="432">
                                             <font key="font" metaFont="smallSystem"/>
@@ -134,7 +134,7 @@
                                         </connections>
                                     </comboBox>
                                     <secureTextField verticalHuggingPriority="750" id="147">
-                                        <rect key="frame" x="152" y="187" width="205" height="19"/>
+                                        <rect key="frame" x="152" y="183" width="205" height="19"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <secureTextFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="433">
                                             <font key="font" metaFont="smallSystem"/>
@@ -150,7 +150,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" id="148">
-                                        <rect key="frame" x="17" y="189" width="130" height="14"/>
+                                        <rect key="frame" x="17" y="185" width="130" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Password del server:" id="434">
                                             <font key="font" metaFont="smallSystem"/>
@@ -159,7 +159,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="149">
-                                        <rect key="frame" x="48" y="217" width="99" height="14"/>
+                                        <rect key="frame" x="48" y="213" width="99" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Nome utente:" id="435">
                                             <font key="font" metaFont="smallSystem"/>
@@ -168,7 +168,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="150">
-                                        <rect key="frame" x="152" y="55" width="205" height="19"/>
+                                        <rect key="frame" x="152" y="51" width="205" height="19"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="436">
                                             <font key="font" metaFont="smallSystem"/>
@@ -182,7 +182,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="151">
-                                        <rect key="frame" x="152" y="214" width="205" height="19"/>
+                                        <rect key="frame" x="152" y="210" width="205" height="19"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="437">
                                             <font key="font" metaFont="smallSystem"/>
@@ -195,7 +195,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="152">
-                                        <rect key="frame" x="73" y="57" width="74" height="14"/>
+                                        <rect key="frame" x="73" y="53" width="74" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Nome reale:" id="438">
                                             <font key="font" metaFont="smallSystem"/>
@@ -204,7 +204,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="197">
-                                        <rect key="frame" x="17" y="96" width="130" height="14"/>
+                                        <rect key="frame" x="17" y="92" width="130" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Soprannomi alternativi:" id="439">
                                             <font key="font" metaFont="smallSystem"/>
@@ -213,7 +213,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="198">
-                                        <rect key="frame" x="152" y="94" width="205" height="19"/>
+                                        <rect key="frame" x="152" y="90" width="205" height="19"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="440">
                                             <font key="font" metaFont="smallSystem"/>
@@ -226,7 +226,7 @@
                                         </connections>
                                     </textField>
                                     <comboBox verticalHuggingPriority="750" id="199">
-                                        <rect key="frame" x="152" y="237" width="70" height="22"/>
+                                        <rect key="frame" x="152" y="233" width="70" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <comboBoxCell key="cell" controlSize="small" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" title="6667" drawsBackground="YES" numberOfVisibleItems="5" id="441">
                                             <font key="font" metaFont="smallSystem"/>
@@ -246,7 +246,7 @@
                                         </connections>
                                     </comboBox>
                                     <textField verticalHuggingPriority="750" id="200">
-                                        <rect key="frame" x="32" y="241" width="115" height="14"/>
+                                        <rect key="frame" x="32" y="237" width="115" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Porta del server:" id="442">
                                             <font key="font" metaFont="smallSystem"/>
@@ -255,7 +255,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" id="233">
-                                        <rect key="frame" x="149" y="11" width="211" height="22"/>
+                                        <rect key="frame" x="149" y="7" width="211" height="22"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" title=" " bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="230" id="443">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -268,7 +268,7 @@
                                         </popUpButtonCell>
                                     </popUpButton>
                                     <textField verticalHuggingPriority="750" id="235">
-                                        <rect key="frame" x="73" y="16" width="74" height="14"/>
+                                        <rect key="frame" x="73" y="12" width="74" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Codifica:" id="444">
                                             <font key="font" metaFont="smallSystem"/>
@@ -277,7 +277,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button id="238">
-                                        <rect key="frame" x="224" y="239" width="40" height="18"/>
+                                        <rect key="frame" x="224" y="235" width="40" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="SSL" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="445">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -288,7 +288,7 @@
                                         </connections>
                                     </button>
                                     <button id="482">
-                                        <rect key="frame" x="267" y="239" width="48" height="18"/>
+                                        <rect key="frame" x="267" y="235" width="48" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="SASL" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="483">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="IxT-PJ-iXo">
                                             <rect key="frame" x="1" y="1" width="247" height="113"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="247" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="gmM-XO-J7d">
                                             <rect key="frame" x="1" y="1" width="247" height="90"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="247" height="90"/>
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="I2m-70-Lwn">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="455">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="464">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="464">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -932,11 +932,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/it.lproj/JVFind.xib
+++ b/Languages/it.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/it.lproj/JVFind.xib
+++ b/Languages/it.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/it.lproj/JVRoomInspector.xib
+++ b/Languages/it.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="Bannati" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="gyT-t0-wp2">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="283" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="Aggiungi ban" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="Cancella ban" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -476,10 +476,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/it.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/it.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/it.lproj/MVBuddyList.xib
+++ b/Languages/it.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="Aggiungi amico" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="Action" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/it.lproj/MVConnections.xib
+++ b/Languages/it.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="YHe-sa-4Se">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="873" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="427" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="427" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="177" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="BsE-zx-ZkH">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="150" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="150" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="817">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="817">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1076,9 +1076,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:808:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1171,7 +1171,5 @@ ANkA2xMXExwTJxMwE0MTRxNSE1sTYBNoE2sTcBN/E4MTihOSE58TpBOmE6gTrRO1E7gTvRPFE8gT2hPd
 E+IAAAAAAAACAQAAAAAAAABBAAAAAAAAAAAAAAAAAAAT5A
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/ja.lproj/JVBuddyInspector.xib
+++ b/Languages/ja.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="識別名を削除します" imageHugsTitle="YES" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="識別名を追加します" imageHugsTitle="YES" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>
@@ -294,7 +294,7 @@
             <rect key="contentRect" x="267" y="404" width="318" height="300"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" autoresizesSubviews="NO" id="215">
-                <rect key="frame" x="1" y="1" width="318" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="318" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" id="249">
@@ -421,7 +421,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="maH-CD-wM2">
                             <rect key="frame" x="1" y="1" width="198" height="97"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="284">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="97"/>
@@ -463,7 +463,7 @@
                     <button toolTip="ドメインを追加します" imageHugsTitle="YES" id="287">
                         <rect key="frame" x="72" y="40" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" enabled="NO" inset="2" id="361">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="361">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                             <string key="keyEquivalent">+</string>
@@ -476,7 +476,7 @@
                     <button toolTip="ドメインを削除します" imageHugsTitle="YES" id="289">
                         <rect key="frame" x="72" y="64" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="362">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="362">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -518,10 +518,8 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
     </resources>

--- a/Languages/ja.lproj/JVConnectionInspector.xib
+++ b/Languages/ja.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="63" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="63" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="450">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="450">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="Vjt-6M-xDI">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="MQ5-bB-HWe">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="79T-VO-Z5s">
                                             <rect key="frame" x="1" y="1" width="288" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="288" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="無視条件を追加します" id="404">
                                         <rect key="frame" x="239" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="453">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="無視条件を削除します" id="406">
                                         <rect key="frame" x="261" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="455">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/ja.lproj/JVConnectionInspector.xib
+++ b/Languages/ja.lproj/JVConnectionInspector.xib
@@ -684,7 +684,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="314" height="282"/>
+                <rect key="frame" x="0.0" y="0.0" width="314" height="282"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="8YR-60-4DJ">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="456">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="456">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="465">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -930,11 +930,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/ja.lproj/JVFind.xib
+++ b/Languages/ja.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/ja.lproj/JVFind.xib
+++ b/Languages/ja.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/ja.lproj/JVRoomInspector.xib
+++ b/Languages/ja.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="追放リスト" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="6Pv-Hr-iRp">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="283" height="206"/>
@@ -301,7 +301,7 @@ DQ
                                     <button toolTip="追放項目を追加します" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="430">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="430">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -323,7 +323,7 @@ DQ
                                     <button toolTip="追放項目を削除します" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="432">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="432">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -463,10 +463,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/ja.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/ja.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/ja.lproj/MVBuddyList.xib
+++ b/Languages/ja.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="友達を追加します" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="アクション" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/ja.lproj/MVConnections.xib
+++ b/Languages/ja.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="3PE-32-Ex5">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="100871" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="351" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="351" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="132" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="uEb-gw-Oos">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="105" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="100809">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="100809">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="105" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="100813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="100813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1076,9 +1076,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:100804:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1171,7 +1171,5 @@ ANkA2xMXExwTJxMwE0MTRxNSE1sTYBNoE2sTcBN/E4MTihOSE58TpBOmE6gTrRO1E7gTvRPFE8gT2hPd
 E+IAAAAAAAACAQAAAAAAAABBAAAAAAAAAAAAAAAAAAAT5A
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/nb.lproj/JVBuddyInspector.xib
+++ b/Languages/nb.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Slett identifiserer" imageHugsTitle="YES" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Legg til identifiserer" imageHugsTitle="YES" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>
@@ -294,7 +294,7 @@
             <rect key="contentRect" x="267" y="404" width="318" height="300"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" autoresizesSubviews="NO" id="215">
-                <rect key="frame" x="1" y="1" width="318" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="318" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" id="249">
@@ -421,7 +421,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="V2N-fr-aVl">
                             <rect key="frame" x="1" y="1" width="198" height="97"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="284">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="97"/>
@@ -463,7 +463,7 @@
                     <button toolTip="Legg til domene" imageHugsTitle="YES" id="287">
                         <rect key="frame" x="72" y="40" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" enabled="NO" inset="2" id="361">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="361">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                             <string key="keyEquivalent">+</string>
@@ -476,7 +476,7 @@
                     <button toolTip="Slett domene" imageHugsTitle="YES" id="289">
                         <rect key="frame" x="72" y="64" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="362">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="362">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -518,10 +518,8 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
     </resources>

--- a/Languages/nb.lproj/JVConnectionInspector.xib
+++ b/Languages/nb.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="63" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="63" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="450">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="450">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="8Op-sn-Pri">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="aol-xz-Gjm">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="LSk-SB-VAY">
                                             <rect key="frame" x="1" y="1" width="288" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="288" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Legg til ignorering" id="404">
                                         <rect key="frame" x="235" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="453">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Slett ignorering" id="406">
                                         <rect key="frame" x="261" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="455">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/nb.lproj/JVConnectionInspector.xib
+++ b/Languages/nb.lproj/JVConnectionInspector.xib
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="5uU-Aw-7BY">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="456">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="456">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="465">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -930,11 +930,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/nb.lproj/JVFind.xib
+++ b/Languages/nb.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/nb.lproj/JVFind.xib
+++ b/Languages/nb.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/nb.lproj/JVRoomInspector.xib
+++ b/Languages/nb.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="Blokkeringer" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="TNB-AO-7Lx">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="283" height="206"/>
@@ -301,7 +301,7 @@ DQ
                                     <button toolTip="Legg til blokkering" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="430">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="430">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -323,7 +323,7 @@ DQ
                                     <button toolTip="Fjern blokkering" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="432">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="432">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -463,10 +463,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/nb.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/nb.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/nb.lproj/MVBuddyList.xib
+++ b/Languages/nb.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="Legg til kompis" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="Handling" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/nb.lproj/MVConnections.xib
+++ b/Languages/nb.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="oD1-Bm-2AC">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="873" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -178,7 +178,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="375" height="419"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView autoresizesSubviews="NO" drawsBackground="NO" type="noTabsNoBorder" id="658">
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" id="658">
                         <rect key="frame" x="4" y="46" width="370" height="242"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="370" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="370" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="151" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="hjq-0Q-kR0">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="124" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="124" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="817">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="817">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1075,9 +1075,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:808:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1170,7 +1170,5 @@ ANkA2xMXExwTJxMwE0MTRxNSE1sTYBNoE2sTcBN/E4MTihOSE58TpBOmE6gTrRO1E7gTvRPFE8gT2hPd
 E+IAAAAAAAACAQAAAAAAAABBAAAAAAAAAAAAAAAAAAAT5A
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/nl.lproj/JVBuddyInspector.xib
+++ b/Languages/nl.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>

--- a/Languages/nl.lproj/JVConnectionInspector.xib
+++ b/Languages/nl.lproj/JVConnectionInspector.xib
@@ -684,7 +684,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="314" height="282"/>
+                <rect key="frame" x="0.0" y="0.0" width="314" height="282"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="0.0" verticalLineScroll="16" verticalPageScroll="0.0" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="LpP-3n-ZZl">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="456">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="456">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="465">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -932,11 +932,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/nl.lproj/JVConnectionInspector.xib
+++ b/Languages/nl.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="94" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="94" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="450">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="450">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="lLM-zd-nmj">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="2pF-PD-zAF">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="lF2-fn-7hP">
                                             <rect key="frame" x="1" y="1" width="323" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="323" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Voeg genegeerde toe" id="404">
                                         <rect key="frame" x="301" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="453">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Verwijder genegeerde" id="406">
                                         <rect key="frame" x="327" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="455">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/nl.lproj/JVFind.xib
+++ b/Languages/nl.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/nl.lproj/JVFind.xib
+++ b/Languages/nl.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,9 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/nl.lproj/JVRoomInspector.xib
+++ b/Languages/nl.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="Verbanningen" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="vKm-Fq-0Tz">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="286" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="Verban" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="Verwijder ban" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -476,10 +476,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/nl.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/nl.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/nl.lproj/MVBuddyList.xib
+++ b/Languages/nl.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="Voeg vriend toe" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="Action" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -157,7 +157,7 @@
             <rect key="contentRect" x="38" y="544" width="510" height="292"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" autoresizesSubviews="NO" id="81">
-                <rect key="frame" x="1" y="9" width="510" height="292"/>
+                <rect key="frame" x="0.0" y="0.0" width="510" height="292"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button verticalHuggingPriority="750" tag="1" imageHugsTitle="YES" id="85">
@@ -226,7 +226,7 @@ Gw
             <rect key="contentRect" x="223" y="383" width="448" height="302"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" autoresizesSubviews="NO" id="114">
-                <rect key="frame" x="1" y="9" width="448" height="302"/>
+                <rect key="frame" x="0.0" y="0.0" width="448" height="302"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" id="116">
@@ -378,7 +378,7 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <clipView key="contentView" id="Gbs-ne-Q9H">
                             <rect key="frame" x="1" y="1" width="192" height="57"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" id="195">
                                     <rect key="frame" x="0.0" y="0.0" width="192" height="57"/>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/nl.lproj/MVConnections.xib
+++ b/Languages/nl.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="fNT-qD-gg2">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="100869" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -178,7 +178,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="362" height="419"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView autoresizesSubviews="NO" drawsBackground="NO" type="noTabsNoBorder" id="658">
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" id="658">
                         <rect key="frame" x="0.0" y="46" width="361" height="242"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="361" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="361" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="142" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="81w-gs-5hN">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="115" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="100809">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="100809">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="115" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="100813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="100813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1077,9 +1077,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:100804:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1172,7 +1172,5 @@ ANkA2xMXExwTJxMwE0MTRxNSE1sTYBNoE2sTcBN/E4MTihOSE58TpBOmE6gTrRO1E7gTvRPFE8gT2hPd
 E+IAAAAAAAACAQAAAAAAAABBAAAAAAAAAAAAAAAAAAAT5A
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/pt-PT.lproj/JVBuddyInspector.xib
+++ b/Languages/pt-PT.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>

--- a/Languages/pt-PT.lproj/JVConnectionInspector.xib
+++ b/Languages/pt-PT.lproj/JVConnectionInspector.xib
@@ -684,7 +684,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="314" height="282"/>
+                <rect key="frame" x="0.0" y="0.0" width="314" height="282"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="4UP-xd-hun">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="52" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="456">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="456">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="34" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="465">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -939,11 +939,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/pt-PT.lproj/JVConnectionInspector.xib
+++ b/Languages/pt-PT.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="106" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="106" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="450">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="450">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="gyN-sP-doW">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="DUc-ea-mFK">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="1Ub-cW-jq5">
                                             <rect key="frame" x="1" y="1" width="320" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="320" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Adicionar regra para ignorar" id="404">
                                         <rect key="frame" x="278" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="453">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Apagar regra para ignorar" id="406">
                                         <rect key="frame" x="304" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="455">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/pt-PT.lproj/JVFind.xib
+++ b/Languages/pt-PT.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -261,10 +261,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/pt-PT.lproj/JVFind.xib
+++ b/Languages/pt-PT.lproj/JVFind.xib
@@ -247,7 +247,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -261,7 +261,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/pt-PT.lproj/JVRoomInspector.xib
+++ b/Languages/pt-PT.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="Indicações de banido" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="342" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="28" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="SyJ-ij-zde">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="283" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="Adicionar indicação de banido" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="28" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="Remover indicação de banido" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="54" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -476,10 +476,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/pt-PT.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/pt-PT.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/pt-PT.lproj/MVBuddyList.xib
+++ b/Languages/pt-PT.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="Adicionar amigo" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="Action" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -488,14 +488,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/pt-PT.lproj/MVConnections.xib
+++ b/Languages/pt-PT.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="ze0-qB-ISM">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="873" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -178,7 +178,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="387" height="419"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView autoresizesSubviews="NO" drawsBackground="NO" type="noTabsNoBorder" id="658">
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" id="658">
                         <rect key="frame" x="2" y="46" width="392" height="242"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="392" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="392" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="173" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="1Fn-Zd-UdN">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="146" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="146" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="817">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="817">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1076,9 +1076,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:808:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1162,7 +1162,5 @@ ETAROBE7EUARTxFTEVoRYhFvEXQRdhF4EX0RhRGIEY0RlRGYEaoRrRGyAAAAAAAAAgEAAAAAAAAAQQAA
 AAAAAAAAAAAAAAAAEbQ
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Languages/zh-Hant.lproj/JVBuddyInspector.xib
+++ b/Languages/zh-Hant.lproj/JVBuddyInspector.xib
@@ -69,7 +69,7 @@
                 <button toolTip="Delete identifier" imageHugsTitle="YES" id="210">
                     <rect key="frame" x="69" y="44" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="348">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="348">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -91,7 +91,7 @@
                 <button toolTip="Add identifier" imageHugsTitle="YES" id="208">
                     <rect key="frame" x="69" y="20" width="23" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="346">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="346">
                         <behavior key="behavior" lightByContents="YES"/>
                         <font key="font" metaFont="label"/>
                         <string key="keyEquivalent">+</string>
@@ -294,7 +294,7 @@
             <rect key="contentRect" x="267" y="404" width="318" height="300"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" autoresizesSubviews="NO" id="215">
-                <rect key="frame" x="1" y="1" width="318" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="318" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" id="249">
@@ -421,7 +421,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="XY1-tZ-tZK">
                             <rect key="frame" x="1" y="1" width="198" height="97"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="284">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="97"/>
@@ -463,7 +463,7 @@
                     <button toolTip="Add domain" imageHugsTitle="YES" id="287">
                         <rect key="frame" x="72" y="40" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" enabled="NO" inset="2" id="361">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="361">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                             <string key="keyEquivalent">+</string>
@@ -476,7 +476,7 @@
                     <button toolTip="Delete domain" imageHugsTitle="YES" id="289">
                         <rect key="frame" x="72" y="64" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="362">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="362">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -518,10 +518,8 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
     </resources>

--- a/Languages/zh-Hant.lproj/JVConnectionInspector.xib
+++ b/Languages/zh-Hant.lproj/JVConnectionInspector.xib
@@ -450,7 +450,7 @@
                                     <button id="181">
                                         <rect key="frame" x="63" y="134" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="448">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="448">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                         </buttonCell>
@@ -462,7 +462,7 @@
                                     <button id="182">
                                         <rect key="frame" x="63" y="153" width="19" height="19"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="449">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="449">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold"/>
                                             <string key="keyEquivalent"></string>
@@ -477,7 +477,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <clipView key="contentView" id="6DT-jf-doB">
                                             <rect key="frame" x="1" y="1" width="228" height="113"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="179">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="113"/>
@@ -529,7 +529,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="WwP-gh-2pA">
                                             <rect key="frame" x="1" y="1" width="228" height="90"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="195">
                                                     <rect key="frame" x="0.0" y="0.0" width="228" height="90"/>
@@ -586,7 +586,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="wRW-n0-hIZ">
                                             <rect key="frame" x="1" y="1" width="288" height="246"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="252">
                                                     <rect key="frame" x="0.0" y="0.0" width="288" height="246"/>
@@ -639,7 +639,7 @@
                                     <button toolTip="Add ignore" id="403">
                                         <rect key="frame" x="235" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="452">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="452">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -661,7 +661,7 @@
                                     <button toolTip="Delete ignore" id="405">
                                         <rect key="frame" x="261" y="5" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" inset="2" id="454">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="454">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>

--- a/Languages/zh-Hant.lproj/JVConnectionInspector.xib
+++ b/Languages/zh-Hant.lproj/JVConnectionInspector.xib
@@ -684,7 +684,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1257"/>
             <value key="minSize" type="size" width="213" height="113"/>
             <view key="contentView" id="329">
-                <rect key="frame" x="1" y="1" width="314" height="282"/>
+                <rect key="frame" x="0.0" y="0.0" width="314" height="282"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="320">
@@ -692,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="l3k-87-AX1">
                             <rect key="frame" x="1" y="1" width="254" height="64"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="322">
                                     <rect key="frame" x="0.0" y="0.0" width="254" height="64"/>
@@ -764,7 +764,7 @@
                     <button id="319">
                         <rect key="frame" x="16" y="63" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="455">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="455">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                             <string key="keyEquivalent"></string>
@@ -777,7 +777,7 @@
                     <button id="339">
                         <rect key="frame" x="16" y="45" width="19" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="464">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="464">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="systemBold"/>
                         </buttonCell>
@@ -930,11 +930,7 @@ Gw
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="addWidget" width="18" height="18"/>
-        <image name="addWidgetSelected" width="18" height="18"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
-        <image name="removeWidget" width="18" height="18"/>
-        <image name="removeWidgetSelected" width="18" height="18"/>
     </resources>
 </document>

--- a/Languages/zh-Hant.lproj/JVFind.xib
+++ b/Languages/zh-Hant.lproj/JVFind.xib
@@ -245,7 +245,7 @@ DQ
                             <imageView id="396">
                                 <rect key="frame" x="2" y="2" width="16" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertCautionIcon" id="413"/>
+                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSCaution" id="413"/>
                             </imageView>
                         </subviews>
                     </customView>
@@ -259,7 +259,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="AlertCautionIcon" width="128" height="128"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="addWidget" width="128" height="128"/>
         <image name="addWidgetSelected" width="128" height="128"/>
         <image name="removeWidget" width="128" height="128"/>

--- a/Languages/zh-Hant.lproj/JVFind.xib
+++ b/Languages/zh-Hant.lproj/JVFind.xib
@@ -72,7 +72,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -86,7 +86,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -259,10 +259,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="271" userLabel="Shared Defaults"/>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSCaution" width="32" height="32"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/zh-Hant.lproj/JVRoomInspector.xib
+++ b/Languages/zh-Hant.lproj/JVRoomInspector.xib
@@ -252,14 +252,14 @@ DQ
                         <tabViewItem label="黑名單" identifier="bans" id="316">
                             <view key="view" autoresizesSubviews="NO" id="317">
                                 <rect key="frame" x="10" y="25" width="315" height="264"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="334">
                                         <rect key="frame" x="15" y="41" width="285" height="208"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" id="bOn-va-DDR">
                                             <rect key="frame" x="1" y="1" width="283" height="206"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" id="335">
                                                     <rect key="frame" x="0.0" y="0.0" width="286" height="206"/>
@@ -314,7 +314,7 @@ DQ
                                     <button toolTip="新增黑名單" imageHugsTitle="YES" id="338">
                                         <rect key="frame" x="15" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addSquareWidget" imagePosition="only" alignment="center" alternateImage="addSquareWidgetPressed" inset="2" id="431">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="431">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                         </buttonCell>
@@ -336,7 +336,7 @@ DQ
                                     <button toolTip="刪除黑名單" imageHugsTitle="YES" id="340">
                                         <rect key="frame" x="41" y="12" width="23" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="deleteWidget" imagePosition="only" alignment="center" alternateImage="deleteWidgetPressed" enabled="NO" inset="2" id="433">
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="433">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="label"/>
                                             <string key="keyEquivalent"></string>
@@ -476,10 +476,8 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="373" userLabel="Shared Defaults"/>
     </objects>
     <resources>
-        <image name="addSquareWidget" width="128" height="128"/>
-        <image name="addSquareWidgetPressed" width="128" height="128"/>
-        <image name="deleteWidget" width="128" height="128"/>
-        <image name="deleteWidgetPressed" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="editWidget" width="22" height="22"/>
         <image name="editWidgetPressed" width="22" height="22"/>
         <image name="room" width="55" height="55"/>

--- a/Languages/zh-Hant.lproj/JVSmartTranscriptFilterSheet.xib
+++ b/Languages/zh-Hant.lproj/JVSmartTranscriptFilterSheet.xib
@@ -59,7 +59,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="removeWidget" imagePosition="only" alignment="center" alternateImage="removeWidgetSelected" enabled="NO" inset="2" id="245">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="245">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -73,7 +73,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="addWidget" imagePosition="only" alignment="center" alternateImage="addWidgetSelected" inset="2" id="246">
+                                            <buttonCell key="dataCell" type="bevel" bezelStyle="regularSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="246">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="cellTitle"/>
                                                 <connections>
@@ -194,9 +194,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/Languages/zh-Hant.lproj/MVBuddyList.xib
+++ b/Languages/zh-Hant.lproj/MVBuddyList.xib
@@ -107,7 +107,7 @@
                     <button toolTip="新增聯絡人" imageHugsTitle="YES" id="39">
                         <rect key="frame" x="61" y="5" width="23" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="buddyNew" imagePosition="only" alignment="center" alternateImage="buddyNewBlue" inset="2" id="204">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="204">
                             <behavior key="behavior" lightByContents="YES"/>
                             <font key="font" metaFont="system" size="10"/>
                         </buttonCell>
@@ -140,7 +140,7 @@
                     <button toolTip="指令" imageHugsTitle="YES" id="105" customClass="MVMenuButton">
                         <rect key="frame" x="6" y="5" width="28" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="actionWidget" imagePosition="only" alignment="left" alternateImage="actionWidgetPressed" id="208">
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="208">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label"/>
                         </buttonCell>
@@ -486,14 +486,12 @@ Gw
         </menu>
     </objects>
     <resources>
-        <image name="actionWidget" width="128" height="128"/>
-        <image name="actionWidgetPressed" width="128" height="128"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="buddyInfo" width="23" height="22"/>
         <image name="buddyInfoBlue" width="23" height="22"/>
         <image name="buddyMessage" width="23" height="22"/>
         <image name="buddyMessageBlue" width="23" height="22"/>
-        <image name="buddyNew" width="128" height="128"/>
-        <image name="buddyNewBlue" width="128" height="128"/>
         <image name="buddyOptions" width="23" height="22"/>
         <image name="buddyOptionsBlue" width="23" height="22"/>
     </resources>

--- a/Languages/zh-Hant.lproj/MVConnections.xib
+++ b/Languages/zh-Hant.lproj/MVConnections.xib
@@ -64,7 +64,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="QHJ-FJ-aev">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="191"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" headerView="873" id="114" customClass="MVTableView">
                                     <rect key="frame" x="0.0" y="0.0" width="350" height="168"/>
@@ -178,7 +178,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="352" height="419"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView autoresizesSubviews="NO" drawsBackground="NO" type="noTabsNoBorder" id="658">
+                    <tabView drawsBackground="NO" type="noTabsNoBorder" id="658">
                         <rect key="frame" x="0.0" y="46" width="351" height="242"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -186,20 +186,20 @@
                             <tabViewItem identifier="0" id="657">
                                 <view key="view" autoresizesSubviews="NO" id="656">
                                     <rect key="frame" x="0.0" y="0.0" width="351" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem identifier="1" id="655">
                                 <view key="view" autoresizesSubviews="NO" id="654">
                                     <rect key="frame" x="0.0" y="0.0" width="351" height="242"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="662">
                                             <rect key="frame" x="132" y="9" width="199" height="79"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="fBn-1i-AzI">
                                                 <rect key="frame" x="1" y="1" width="197" height="77"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="673">
                                                         <rect key="frame" x="0.0" y="0.0" width="402" height="77"/>
@@ -283,7 +283,7 @@
                                         <button imageHugsTitle="YES" id="667">
                                             <rect key="frame" x="105" y="9" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="addWidget" imagePosition="overlaps" alignment="center" alternateImage="addWidgetSelected" inset="2" id="813">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="813">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                             </buttonCell>
@@ -325,7 +325,7 @@
                                         <button imageHugsTitle="YES" id="672">
                                             <rect key="frame" x="105" y="28" width="19" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="removeWidget" imagePosition="overlaps" alignment="center" alternateImage="removeWidgetSelected" transparent="YES" inset="2" id="817">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="817">
                                                 <behavior key="behavior" lightByContents="YES"/>
                                                 <font key="font" metaFont="systemBold"/>
                                                 <string key="keyEquivalent"></string>
@@ -1075,9 +1075,9 @@ Gw
         </window>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="addWidget" width="128" height="128"/>
-        <image name="addWidgetSelected" width="128" height="128"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:808:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
@@ -1161,7 +1161,5 @@ ETAROBE7EUARTxFTEVoRYhFvEXQRdhF4EX0RhRGIEY0RlRGYEaoRrRGyAAAAAAAAAgEAAAAAAAAAQQAA
 AAAAAAAAAAAAAAAAEbQ
 </mutableData>
         </image>
-        <image name="removeWidget" width="128" height="128"/>
-        <image name="removeWidgetSelected" width="128" height="128"/>
     </resources>
 </document>

--- a/Resources/JVChatWindow.xib
+++ b/Resources/JVChatWindow.xib
@@ -67,7 +67,7 @@
                 <button id="289" customClass="MVMenuButton">
                     <rect key="frame" x="1" y="-1" width="28" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" id="299">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="299">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -77,7 +77,7 @@
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="qC8-gg-ve5">
                         <rect key="frame" x="1" y="1" width="188" height="93"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="20" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="240" id="241" customClass="ASExtendedOutlineView">
                                 <rect key="frame" x="0.0" y="0.0" width="188" height="93"/>

--- a/Resources/JVSidebarChatWindow.xib
+++ b/Resources/JVSidebarChatWindow.xib
@@ -96,7 +96,7 @@
                                             <button id="316" customClass="MVMenuButton">
                                                 <rect key="frame" x="-1" y="0.0" width="32" height="23"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
-                                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="center" alternateImage="sidebarActionWidgetPressed" inset="2" id="331">
+                                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="331">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
@@ -130,7 +130,6 @@
     </objects>
     <resources>
         <image name="NSActionTemplate" width="14" height="14"/>
-        <image name="sidebarActionWidgetPressed" width="32" height="23"/>
         <image name="sidebarFavoritesWidget" width="32" height="23"/>
         <image name="sidebarFavoritesWidgetPressed" width="32" height="23"/>
     </resources>

--- a/Resources/JVTabbedChatWindow.xib
+++ b/Resources/JVTabbedChatWindow.xib
@@ -95,7 +95,7 @@
                 <button id="27" customClass="MVMenuButton">
                     <rect key="frame" x="1" y="-1" width="28" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" id="46">
+                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" id="46">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="label"/>
                     </buttonCell>
@@ -105,7 +105,7 @@
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="j7F-YI-f5Y">
                         <rect key="frame" x="1" y="1" width="188" height="93"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="20" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="26" id="28" customClass="ASExtendedOutlineView">
                                 <rect key="frame" x="0.0" y="0.0" width="188" height="93"/>


### PR DESCRIPTION
This replaces the outdated (and removed) widget icons with system-supplied template versions.

Also adds borders around buttons that used to have that look in older versions of Colloquy.