### PR TITLE
OSType NS_ENUMs

### DIFF
--- a/Additions/NSStringAdditions.h
+++ b/Additions/NSStringAdditions.h
@@ -19,8 +19,8 @@ COLLOQUY_EXPORT BOOL isValidUTF8( const char *string, NSUInteger length );
 + (NSString *) locallyUniqueString;
 
 #if ENABLE(SCRIPTING)
-+ (unsigned long) scriptTypedEncodingFromStringEncoding:(NSStringEncoding) encoding;
-+ (NSStringEncoding) stringEncodingFromScriptTypedEncoding:(unsigned long) encoding;
++ (OSType) scriptTypedEncodingFromStringEncoding:(NSStringEncoding) encoding;
++ (NSStringEncoding) stringEncodingFromScriptTypedEncoding:(OSType) encoding;
 #endif
 
 + (NSArray <NSString *> *) knownEmoticons;

--- a/Additions/NSStringAdditions.m
+++ b/Additions/NSStringAdditions.m
@@ -436,7 +436,7 @@ static NSString *colorForHTML( unsigned char red, unsigned char green, unsigned 
 }
 
 #if ENABLE(SCRIPTING)
-+ (unsigned long) scriptTypedEncodingFromStringEncoding:(NSStringEncoding) encoding {
++ (OSType) scriptTypedEncodingFromStringEncoding:(NSStringEncoding) encoding {
 	switch( encoding ) {
 		default:
 		case NSUTF8StringEncoding: return 'utF8';
@@ -485,7 +485,7 @@ static NSString *colorForHTML( unsigned char red, unsigned char green, unsigned 
 	return 'utF8'; // default encoding
 }
 
-+ (NSStringEncoding) stringEncodingFromScriptTypedEncoding:(unsigned long) encoding {
++ (NSStringEncoding) stringEncodingFromScriptTypedEncoding:(OSType) encoding {
 	switch( encoding ) {
 		default:
 		case 'utF8': return NSUTF8StringEncoding;

--- a/Chat Core/MVChatConnection.h
+++ b/Chat Core/MVChatConnection.h
@@ -7,7 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, MVChatConnectionType) {
+typedef NS_ENUM(OSType, MVChatConnectionType) {
 	MVChatConnectionUnsupportedType = 0,
 	MVChatConnectionICBType = 'icbC',
 	MVChatConnectionIRCType = 'ircC',
@@ -15,7 +15,7 @@ typedef NS_ENUM(NSInteger, MVChatConnectionType) {
 	MVChatConnectionXMPPType = 'xmpC'
 };
 
-typedef NS_ENUM(NSInteger, MVChatConnectionStatus) {
+typedef NS_ENUM(OSType, MVChatConnectionStatus) {
 	MVChatConnectionDisconnectedStatus = 'disC',
 	MVChatConnectionServerDisconnectedStatus = 'sdsC',
 	MVChatConnectionConnectingStatus = 'conG',
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, MVChatConnectionStatus) {
 	MVChatConnectionSuspendedStatus = 'susP'
 };
 
-typedef NS_ENUM(NSInteger, MVChatConnectionProxy) {
+typedef NS_ENUM(OSType, MVChatConnectionProxy) {
 	MVChatConnectionNoProxy = 'nonE',
 	MVChatConnectionHTTPProxy = 'httP',
 	MVChatConnectionHTTPSProxy = 'htpS',
@@ -31,18 +31,18 @@ typedef NS_ENUM(NSInteger, MVChatConnectionProxy) {
 	MVChatConnectionSOCKS5Proxy = 'soK5'
 };
 
-typedef NS_ENUM(NSInteger, MVChatConnectionBouncer) {
+typedef NS_ENUM(OSType, MVChatConnectionBouncer) {
 	MVChatConnectionNoBouncer = 'nonB',
 	MVChatConnectionGenericBouncer = 'gbnC',
 	MVChatConnectionColloquyBouncer = 'cbnC'
 };
 
-typedef NS_ENUM(NSInteger, MVChatConnectionPublicKeyType) {
+typedef NS_ENUM(OSType, MVChatConnectionPublicKeyType) {
 	MVChatConnectionServerPublicKeyType = 'serV',
 	MVChatConnectionClientPublicKeyType = 'clnT'
 };
 
-typedef NS_ENUM(NSInteger, MVChatMessageFormat) {
+typedef NS_ENUM(OSType, MVChatMessageFormat) {
 	MVChatConnectionDefaultMessageFormat = 'cDtF',
 	MVChatNoMessageFormat = 'nOcF',
 	MVChatWindowsIRCMessageFormat = 'mIrF',

--- a/Chat Core/MVChatUser.h
+++ b/Chat Core/MVChatUser.h
@@ -6,13 +6,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, MVChatUserType) {
+typedef NS_ENUM(OSType, MVChatUserType) {
 	MVChatRemoteUserType = 'remT',
 	MVChatLocalUserType = 'locL',
 	MVChatWildcardUserType = 'wilD'
 };
 
-typedef NS_ENUM(NSInteger, MVChatUserStatus) {
+typedef NS_ENUM(OSType, MVChatUserStatus) {
 	MVChatUserUnknownStatus = 'uKnw',
 	MVChatUserOfflineStatus = 'oflN',
 	MVChatUserDetachedStatus = 'detA',

--- a/Chat Core/MVDirectChatConnection.h
+++ b/Chat Core/MVDirectChatConnection.h
@@ -15,12 +15,12 @@ COLLOQUY_EXPORT extern NSString *MVDirectChatConnectionGotMessageNotification;
 
 COLLOQUY_EXPORT extern NSString *MVDirectChatConnectionErrorDomain;
 
-typedef enum {
+typedef NS_ENUM(OSType, MVDirectChatConnectionStatus) {
 	MVDirectChatConnectionConnectedStatus = 'dcCo',
 	MVDirectChatConnectionWaitingStatus = 'dcWa',
 	MVDirectChatConnectionDisconnectedStatus = 'dcDs',
 	MVDirectChatConnectionErrorStatus = 'dcEr'
-} MVDirectChatConnectionStatus;
+};
 
 @class MVChatUser;
 

--- a/Chat Core/MVFileTransfer.h
+++ b/Chat Core/MVFileTransfer.h
@@ -13,7 +13,7 @@ COLLOQUY_EXPORT extern NSString *MVFileTransferErrorOccurredNotification;
 
 COLLOQUY_EXPORT extern NSString *MVFileTransferErrorDomain;
 
-typedef NS_ENUM(NSInteger, MVFileTransferStatus) {
+typedef NS_ENUM(OSType, MVFileTransferStatus) {
 	MVFileTransferDoneStatus = 'trDn',
 	MVFileTransferNormalStatus = 'trNo',
 	MVFileTransferHoldingStatus = 'trHo',

--- a/Controllers/MVBuddyListController.h
+++ b/Controllers/MVBuddyListController.h
@@ -7,7 +7,7 @@
 @class ABPeoplePickerController;
 @class MVChatConnection;
 
-typedef NS_ENUM(NSInteger, MVBuddyListSortOrder) {
+typedef NS_ENUM(OSType, MVBuddyListSortOrder) {
 	MVAvailabilitySortOrder = 'avlY',
 	MVFirstNameSortOrder = 'fSnM',
 	MVLastNameSortOrder = 'lSnM',

--- a/Models/JVChatMessage.h
+++ b/Models/JVChatMessage.h
@@ -1,10 +1,10 @@
 #import "JVChatTranscript.h"
 #import "KAIgnoreRule.h"
 
-typedef enum _JVChatMessageType {
+typedef NS_ENUM(OSType, JVChatMessageType) {
 	JVChatMessageNormalType = 'noMt',
 	JVChatMessageNoticeType = 'nTMt'
-} JVChatMessageType;
+};
 
 @interface JVChatMessage : NSObject <NSMutableCopying, JVChatTranscriptElement> {
 	@public

--- a/Shared/Models/KAIgnoreRule.h
+++ b/Shared/Models/KAIgnoreRule.h
@@ -5,7 +5,7 @@
 @protocol JVChatViewController;
 #endif
 
-typedef NS_ENUM(NSInteger, JVIgnoreMatchResult) {
+typedef NS_ENUM(OSType, JVIgnoreMatchResult) {
 	JVUserIgnored = 'usIg',
 	JVMessageIgnored = 'msIg',
 	JVNotIgnored = 'noIg'


### PR DESCRIPTION
This changes all the four-character type enums to `OSType`.