### PR TITLE
Minor fixes:

### DIFF
--- a/Additions/MVUtilities.h
+++ b/Additions/MVUtilities.h
@@ -1,4 +1,4 @@
-#import <pthread.h>
+#include <pthread.h>
 
 #define MVInline static __inline__ __attribute__((always_inline))
 

--- a/Additions/NSAttributedStringMoreAdditions.m
+++ b/Additions/NSAttributedStringMoreAdditions.m
@@ -5,7 +5,7 @@
 #import "NSAttributedStringMoreAdditions.h"
 #import <ChatCore/NSRegularExpressionAdditions.h>
 
-#import <libxml/tree.h>
+#include <libxml/tree.h>
 
 static void setItalicOrObliqueFont( NSMutableDictionary *attrs ) {
 	NSFontManager *fm = [NSFontManager sharedFontManager];

--- a/Additions/NSNotificationAdditions.m
+++ b/Additions/NSNotificationAdditions.m
@@ -1,5 +1,5 @@
 #import "NSNotificationAdditions.h"
-#import <pthread.h>
+#include <pthread.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Additions/NSStringAdditions.m
+++ b/Additions/NSStringAdditions.m
@@ -4,7 +4,7 @@
 #import "NSScannerAdditions.h"
 #import "NSRegularExpressionAdditions.h"
 
-#import <sys/time.h>
+#include <sys/time.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Chat Core/InterThreadMessaging.m
+++ b/Chat Core/InterThreadMessaging.m
@@ -37,7 +37,7 @@ MVInline BOOL useSystemThreadPerformSelector() {
 
 #if !ALWAYS_HAS_SYSTEM_SUPPORT
 
-#import <pthread.h>
+#include <pthread.h>
 
 typedef struct InterThreadMessage {
 	SEL selector;

--- a/Chat Core/MVChatConnection.h
+++ b/Chat Core/MVChatConnection.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <SystemConfiguration/SCNetworkReachability.h>
+#include <SystemConfiguration/SCNetworkReachability.h>
 
 #import <ChatCore/MVAvailability.h>
 #import <ChatCore/MVChatString.h>

--- a/Chat Core/MVChatPluginManager.h
+++ b/Chat Core/MVChatPluginManager.h
@@ -28,11 +28,11 @@ COLLOQUY_EXPORT
 - (NSArray *) makePluginsOfClass:(Class __nullable) class performInvocation:(NSInvocation *) invocation stoppingOnFirstSuccessfulReturn:(BOOL) stop;
 @end
 
-@protocol MVChatPlugin
+@protocol MVChatPlugin <NSObject>
 - (id) initWithManager:(MVChatPluginManager *) manager;
-@end
 
-@interface NSObject (MVChatPluginReloadSupport)
+#pragma mark MVChatPluginReloadSupport
+@optional
 - (void) load;
 - (void) unload;
 @end

--- a/Chat Core/MVDirectClientConnection.m
+++ b/Chat Core/MVDirectClientConnection.m
@@ -13,7 +13,7 @@
 #import <TCMPortMapper/TCMPortMapper.h>
 #endif
 
-#import <arpa/inet.h>
+#include <arpa/inet.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Chat Core/MVICBChatConnection.m
+++ b/Chat Core/MVICBChatConnection.m
@@ -34,7 +34,7 @@
 
 #import "MVICBChatConnection.h"
 
-#import <stdarg.h>
+#include <stdarg.h>
 #import <Foundation/Foundation.h>
 
 @import CocoaAsyncSocket;

--- a/Chat Core/MVIRCChatConnection.m
+++ b/Chat Core/MVIRCChatConnection.m
@@ -29,7 +29,7 @@
 #endif
 
 #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-#import <CFNetwork/CFNetwork.h>
+#include <CFNetwork/CFNetwork.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Chat Core/MVIRCFileTransfer.m
+++ b/Chat Core/MVIRCFileTransfer.m
@@ -9,7 +9,7 @@
 #import "MVUtilities.h"
 #import "NSNotificationAdditions.h"
 
-#import <arpa/inet.h>
+#include <arpa/inet.h>
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Controllers/JVChatController.m
+++ b/Controllers/JVChatController.m
@@ -368,7 +368,7 @@ static NSMenu *smartTranscriptMenu = nil;
 	NSParameterAssert( panel != nil );
 
 	if( [panel respondsToSelector:@selector( willDispose )] )
-		[(NSObject *)panel willDispose];
+		[panel willDispose];
 
 	[[panel windowController] removeChatViewController:panel];
 	[_chatControllers removeObject:panel];
@@ -403,7 +403,7 @@ static NSMenu *smartTranscriptMenu = nil;
 	NSParameterAssert( controller != nil );
 
 	if( [controller respondsToSelector:@selector( willDispose )] )
-		[(NSObject *)controller willDispose];
+		[controller willDispose];
 
 	[[controller windowController] removeChatViewController:controller];
 

--- a/Controllers/JVChatController.m
+++ b/Controllers/JVChatController.m
@@ -13,7 +13,7 @@
 #import "JVChatMessage.h"
 #import "JVChatRoomMember.h"
 
-#import <libxml/parser.h>
+#include <libxml/parser.h>
 
 static JVChatController *sharedInstance = nil;
 static NSMenu *smartTranscriptMenu = nil;

--- a/Controllers/JVChatWindowController.h
+++ b/Controllers/JVChatWindowController.h
@@ -110,9 +110,8 @@ extern NSString *JVChatViewPboardType;
 - (NSString *) toolbarIdentifier;
 - (NSString *) windowTitle;
 - (NSString *) identifier;
-@end
 
-@interface NSObject (JVChatViewControllerOptional)
+@optional
 - (void) willSelect;
 - (void) didSelect;
 
@@ -122,7 +121,7 @@ extern NSString *JVChatViewPboardType;
 - (void) willDispose;
 @end
 
-@protocol JVChatListItemScripting
+@protocol JVChatListItemScripting <NSObject>
 - (NSNumber *) uniqueIdentifier;
 - (NSArray *) children;
 - (NSString *) information;
@@ -139,9 +138,8 @@ extern NSString *JVChatViewPboardType;
 - (id <JVChatListItem>) parent;
 - (NSImage *) icon;
 - (NSString *) title;
-@end
 
-@interface NSObject (JVChatListItemOptional)
+@optional
 - (BOOL) acceptsDraggedFileOfType:(NSString *) type;
 - (void) handleDraggedFile:(NSString *) path;
 - (IBAction) doubleClicked:(id) sender;

--- a/Controllers/JVChatWindowController.m
+++ b/Controllers/JVChatWindowController.m
@@ -1064,9 +1064,9 @@ NSString *JVChatViewPboardType = @"Colloquy Chat View v1.0 pasteboard type";
 	if( ( [item conformsToProtocol:@protocol( JVChatViewController )] && item != (id) _activeViewController ) || ( ! _activeViewController && [[item parent] conformsToProtocol:@protocol( JVChatViewController )] && ( item = [item parent] ) ) ) {
 		id lastActive = _activeViewController;
 		if( [_activeViewController respondsToSelector:@selector( willUnselect )] )
-			[(NSObject *)_activeViewController willUnselect];
+			[_activeViewController willUnselect];
 		if( [item respondsToSelector:@selector( willSelect )] )
-			[(NSObject *)item willSelect];
+			[item willSelect];
 
 		_activeViewController = item;
 
@@ -1076,9 +1076,9 @@ NSString *JVChatViewPboardType = @"Colloquy Chat View v1.0 pasteboard type";
 		[self _refreshToolbar];
 
 		if( [lastActive respondsToSelector:@selector( didUnselect )] )
-			[(NSObject *)lastActive didUnselect];
+			[lastActive didUnselect];
 		if( [_activeViewController respondsToSelector:@selector( didSelect )] )
-			[(NSObject *)_activeViewController didSelect];
+			[_activeViewController didSelect];
 	} else if( ! [_views count] || ! _activeViewController ) {
 		NSView *placeHolder = [[NSView alloc] initWithFrame:[[[self window] contentView] frame]];
 		[[self window] setContentView:placeHolder];

--- a/Controllers/JVInspectorController.h
+++ b/Controllers/JVInspectorController.h
@@ -5,9 +5,8 @@
 - (NSSize) minSize;
 - (NSString *) title;
 - (NSString *) type;
-@end
 
-@interface NSObject (JVInspectorOptional)
+@optional
 - (void) willLoad;
 - (void) didLoad;
 
@@ -17,9 +16,8 @@
 
 @protocol JVInspection <NSObject>
 - (id <JVInspector>) inspector;
-@end
 
-@interface NSObject (JVInspectionOptional)
+@optional
 - (void) willBeInspected;
 @end
 

--- a/Controllers/JVInspectorController.m
+++ b/Controllers/JVInspectorController.m
@@ -70,7 +70,7 @@ static NSMutableSet *inspectors = nil;
 		[[self window] close];
 
 	if( [_inspector respondsToSelector:@selector( didUnload )] )
-		[(NSObject *)_inspector didUnload];
+		[_inspector didUnload];
 
 	_inspectorLoaded = NO;
 
@@ -112,7 +112,7 @@ static NSMutableSet *inspectors = nil;
 	if( object == _object ) return;
 
 	if( [_inspector respondsToSelector:@selector( shouldUnload )] )
-		if( ! [(NSObject *)_inspector shouldUnload] ) return;
+		if( ! [_inspector shouldUnload] ) return;
 
 	_object = object;
 
@@ -122,7 +122,7 @@ static NSMutableSet *inspectors = nil;
 
 	if( [[self window] isVisible] ) {
 		if( [oldInspector respondsToSelector:@selector( didUnload )] )
-			[(NSObject *)oldInspector didUnload];
+			[oldInspector didUnload];
 		[self _loadInspector];
 	}
 }
@@ -143,7 +143,7 @@ static NSMutableSet *inspectors = nil;
 	BOOL should = YES;
 
 	if( [_inspector respondsToSelector:@selector( shouldUnload )] )
-		should = [(NSObject *)_inspector shouldUnload];
+		should = [_inspector shouldUnload];
 
 	if( should ) {
 		[inspectors removeObject:self];
@@ -170,10 +170,10 @@ static NSMutableSet *inspectors = nil;
 	NSView *view = [_inspector view];
 
 	if( [_object respondsToSelector:@selector( willBeInspected )] )
-		[(NSObject *)_object willBeInspected];
+		[_object willBeInspected];
 
 	if( [_inspector respondsToSelector:@selector( willLoad )] )
-		[(NSObject *)_inspector willLoad];
+		[_inspector willLoad];
 
 	if( view && _inspector ) {
 		NSRect windowFrame = [[[self window] contentView] frame];
@@ -189,7 +189,7 @@ static NSMutableSet *inspectors = nil;
 		[[self window] setContentView:view];
 
 		if( [_inspector respondsToSelector:@selector( didLoad )] )
-			[(NSObject *)_inspector didLoad];
+			[_inspector didLoad];
 		_inspectorLoaded = YES;
 	} else {
 		[[self window] setTitle:NSLocalizedString( @"No Info", "no info inspector title" )];
@@ -212,6 +212,6 @@ static NSMutableSet *inspectors = nil;
 
 - (void) _applicationQuitting:(NSNotification *) notification {
 	if( _inspectorLoaded && [_inspector respondsToSelector:@selector( didUnload )] )
-		[(NSObject *)_inspector didUnload];
+		[_inspector didUnload];
 }
 @end

--- a/Controllers/JVSidebarChatWindowController.m
+++ b/Controllers/JVSidebarChatWindowController.m
@@ -82,9 +82,9 @@
 	if( ( [item conformsToProtocol:@protocol( JVChatViewController )] && item != (id) _activeViewController ) || ( ! _activeViewController && [[item parent] conformsToProtocol:@protocol( JVChatViewController )] && ( item = [item parent] ) ) ) {
 		id lastActive = _activeViewController;
 		if( [_activeViewController respondsToSelector:@selector( willUnselect )] )
-			[(NSObject *)_activeViewController willUnselect];
+			[_activeViewController willUnselect];
 		if( [item respondsToSelector:@selector( willSelect )] )
-			[(NSObject *)item willSelect];
+			[item willSelect];
 
 		_activeViewController = item;
 
@@ -100,9 +100,9 @@
 		[self _refreshToolbar];
 
 		if( [lastActive respondsToSelector:@selector( didUnselect )] )
-			[(NSObject *)lastActive didUnselect];
+			[lastActive didUnselect];
 		if( [_activeViewController respondsToSelector:@selector( didSelect )] )
-			[(NSObject *)_activeViewController didSelect];
+			[_activeViewController didSelect];
 	} else if( ! [_views count] || ! _activeViewController ) {
 		[[[bodyView subviews] lastObject] removeFromSuperview];
 		[[[self window] toolbar] setDelegate:nil];

--- a/Controllers/JVTabbedChatWindowController.m
+++ b/Controllers/JVTabbedChatWindowController.m
@@ -291,7 +291,7 @@
 
 - (NSString *) customTabView:(AICustomTabsView *) view toolTipForTabViewItem:(NSTabViewItem *) tabViewItem {
 	if( [[(JVChatTabItem *)tabViewItem chatViewController] respondsToSelector:@selector( toolTip )] )
-		return [(NSObject *)[(JVChatTabItem *)tabViewItem chatViewController] toolTip];
+		return [[(JVChatTabItem *)tabViewItem chatViewController] toolTip];
 	return nil;
 }
 
@@ -306,8 +306,8 @@
 	BOOL accepted = NO;
 
 	for( id file in files ) {
-		if( [(NSObject *)[(JVChatTabItem *)tabViewItem chatViewController] acceptsDraggedFileOfType:[file pathExtension]] ) {
-			[(NSObject *)[(JVChatTabItem *)tabViewItem chatViewController] handleDraggedFile:file];
+		if( [[(JVChatTabItem *)tabViewItem chatViewController] acceptsDraggedFileOfType:[file pathExtension]] ) {
+			[[(JVChatTabItem *)tabViewItem chatViewController] handleDraggedFile:file];
 			accepted = YES;
 		}
 	}
@@ -515,9 +515,9 @@
 	if( ( [item conformsToProtocol:@protocol( JVChatViewController )] && item != (id) _activeViewController ) || ( ! _activeViewController && [[item parent] conformsToProtocol:@protocol( JVChatViewController )] && ( item = [item parent] ) ) ) {
 		id lastActive = _activeViewController;
 		if( [_activeViewController respondsToSelector:@selector( willUnselect )] )
-			[(NSObject *)_activeViewController willUnselect];
+			[_activeViewController willUnselect];
 		if( [item respondsToSelector:@selector( willSelect )] )
-			[(NSObject *)item willSelect];
+			[item willSelect];
 
 		_activeViewController = item;
 
@@ -526,9 +526,9 @@
 		[self _refreshToolbar];
 
 		if( [lastActive respondsToSelector:@selector( didUnselect )] )
-			[(NSObject *)lastActive didUnselect];
+			[lastActive didUnselect];
 		if( [_activeViewController respondsToSelector:@selector( didSelect )] )
-			[(NSObject *)_activeViewController didSelect];
+			[_activeViewController didSelect];
 	} else if( ! [_views count] || ! _activeViewController ) {
 		[[self window] setContentView:[[NSView alloc] initWithFrame:[[[self window] contentView] frame]]];
 		[[[self window] toolbar] setDelegate:nil];

--- a/Controllers/MVCrashCatcher.m
+++ b/Controllers/MVCrashCatcher.m
@@ -1,5 +1,5 @@
 #import "MVCrashCatcher.h"
-#import <sys/sysctl.h>
+#include <sys/sysctl.h>
 
 static MVCrashCatcher *crashCatcher = nil;
 

--- a/Importer/GetMetadataForFile.m
+++ b/Importer/GetMetadataForFile.m
@@ -1,7 +1,7 @@
-#import <CoreServices/CoreServices.h>
+#include <CoreServices/CoreServices.h>
 #import <Foundation/Foundation.h>
-#import <libxml/tree.h>
-#import <libxml/xmlerror.h>
+#include <libxml/tree.h>
+#include <libxml/xmlerror.h>
 
 /* Sample transcript:
 <log began="2005-07-11 12:19:09 -0400" source="irc://irc.freenode.net/%23barcamp">

--- a/Models/JVChatEvent.m
+++ b/Models/JVChatEvent.m
@@ -3,7 +3,7 @@
 #import "NSDateAdditions.h"
 #import "JVChatRoomMember.h"
 
-#import <libxml/tree.h>
+#include <libxml/tree.h>
 
 @implementation JVChatEvent
 - (void) dealloc {

--- a/Models/JVChatMessage.m
+++ b/Models/JVChatMessage.m
@@ -1,4 +1,4 @@
-#import <libxml/tree.h>
+#include <libxml/tree.h>
 
 #import "JVChatMessage.h"
 #import "JVBuddy.h"

--- a/Models/JVChatSession.m
+++ b/Models/JVChatSession.m
@@ -1,5 +1,5 @@
 #import "JVChatSession.h"
-#import <libxml/tree.h>
+#include <libxml/tree.h>
 
 @implementation JVChatSession
 - (void) dealloc {

--- a/Models/JVChatTranscript.h
+++ b/Models/JVChatTranscript.h
@@ -5,7 +5,7 @@
 
 extern NSString *JVChatTranscriptUpdatedNotification;
 
-@protocol JVChatTranscriptElement
+@protocol JVChatTranscriptElement <NSObject>
 - (/* xmlNode */ void *) node;
 - (JVChatTranscript *) transcript;
 @end

--- a/Models/JVChatTranscript.m
+++ b/Models/JVChatTranscript.m
@@ -6,7 +6,7 @@
 #import "NSAttributedStringMoreAdditions.h"
 #import "NSDateAdditions.h"
 
-#import <libxml/tree.h>
+#include <libxml/tree.h>
 
 NSString *JVChatTranscriptUpdatedNotification = @"JVChatTranscriptUpdatedNotification";
 

--- a/Models/JVStyle.m
+++ b/Models/JVStyle.m
@@ -1,6 +1,6 @@
-#import <libxml/tree.h>
-#import <libxslt/transform.h>
-#import <libxslt/xsltutils.h>
+#include <libxml/tree.h>
+#include <libxslt/transform.h>
+#include <libxslt/xsltutils.h>
 
 #import "JVStyle.h"
 #import "JVEmoticonSet.h"
@@ -416,11 +416,11 @@ NSString *JVStyleVariantChangedNotification = @"JVStyleVariantChangedNotificatio
 #pragma mark -
 
 - (NSURL *) baseLocation {
-	return [NSURL fileURLWithPath:[_bundle resourcePath]];
+	return [_bundle resourceURL];
 }
 
 - (NSURL *) mainStyleSheetLocation {
-	return [NSURL fileURLWithPath:[_bundle pathForResource:@"main" ofType:@"css"]];
+	return [_bundle URLForResource:@"main" withExtension:@"css"];
 }
 
 - (NSURL *) variantStyleSheetLocationWithName:(NSString *) name {

--- a/Models/MVKeyChain.h
+++ b/Models/MVKeyChain.h
@@ -1,4 +1,4 @@
-#import <Security/Security.h>
+#include <Security/Security.h>
 
 enum {
 	MVKeyChainAuthenticationTypeAny = 0,

--- a/Panels/JVChatRoomMember.m
+++ b/Panels/JVChatRoomMember.m
@@ -345,7 +345,7 @@
 		[item setTarget:self];
 		[menu addItem:item];
 
-		item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString( [NSString stringWithUTF8String:"Kick From Room..."], "kick from room (customized) contextual menu - admin only" ) action:@selector( customKick: ) keyEquivalent:@""];
+		item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString( @"Kick From Room...", "kick from room (customized) contextual menu - admin only" ) action:@selector( customKick: ) keyEquivalent:@""];
 		[item setKeyEquivalentModifierMask:NSAlternateKeyMask];
 		[item setAlternate:YES];
 		[item setTarget:self];
@@ -356,7 +356,7 @@
 			[item setTarget:self];
 			[menu addItem:item];
 
-			item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString( [NSString stringWithUTF8String:"Ban From Room..."], "ban from room (customized) contextual menu - admin only" ) action:@selector( customBan: ) keyEquivalent:@""];
+			item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString( @"Ban From Room...", "ban from room (customized) contextual menu - admin only" ) action:@selector( customBan: ) keyEquivalent:@""];
 			[item setKeyEquivalentModifierMask:NSAlternateKeyMask];
 			[item setAlternate:YES];
 			[item setTarget:self];
@@ -366,7 +366,7 @@
 			[item setTarget:self];
 			[menu addItem:item];
 
-			item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString( [NSString stringWithUTF8String:"Kick & Ban From Room..."], "kickban from room (customized) contextual menu - admin only" ) action:@selector( customKickban: ) keyEquivalent:@""];
+			item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString( @"Kick & Ban From Room...", "kickban from room (customized) contextual menu - admin only" ) action:@selector( customKickban: ) keyEquivalent:@""];
 			[item setKeyEquivalentModifierMask:NSAlternateKeyMask];
 			[item setAlternate:YES];
 			[item setTarget:self];

--- a/Plug-Ins/Python Support/JVPythonChatPlugin.h
+++ b/Plug-Ins/Python Support/JVPythonChatPlugin.h
@@ -1,5 +1,5 @@
 #import "MVChatPluginManager.h"
-#import <Python.h>
+#include <Python.h>
 
 extern NSString *JVPythonErrorDomain;
 

--- a/Plug-Ins/Python Support/pyobjc-compat.h
+++ b/Plug-Ins/Python Support/pyobjc-compat.h
@@ -21,7 +21,7 @@
 #define likely(x)	x 
 #endif
 
-#import <AvailabilityMacros.h>
+#include <AvailabilityMacros.h>
 /* On 10.1 there are no defines for the OS version. */
 #ifndef MAC_OS_X_VERSION_10_1
 #define MAC_OS_X_VERSION_10_1 1010

--- a/Shared/Controllers/CQKeychain.m
+++ b/Shared/Controllers/CQKeychain.m
@@ -1,6 +1,6 @@
 #import "CQKeychain.h"
 
-#import <Security/Security.h>
+#include <Security/Security.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Views/AICustomTabCell.h
+++ b/Views/AICustomTabCell.h
@@ -13,7 +13,7 @@
  | write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  \------------------------------------------------------------------------------------------------------ */
 
-@protocol AICustomTabViewItem
+@protocol AICustomTabViewItem <NSObject>
 - (NSString *)label;
 - (NSImage *)icon;
 - (BOOL) isEnabled;

--- a/Views/AICustomTabsView.h
+++ b/Views/AICustomTabsView.h
@@ -18,7 +18,8 @@
 
 @class AICustomTabCell, AICustomTabsView;
 
-@interface NSObject (AICustomTabsViewDelegate)
+@protocol AICustomTabsViewDelegate <NSObject>
+@optional
 - (void)customTabView:(AICustomTabsView *)tabView didSelectTabViewItem:(NSTabViewItem *)tabViewItem;
 - (void)customTabView:(AICustomTabsView *)tabView closeTabViewItem:(NSTabViewItem *)tabViewItem;
 - (void)customTabViewDidChangeNumberOfTabViewItems:(AICustomTabsView *)tabView;

--- a/Views/MVTableView.h
+++ b/Views/MVTableView.h
@@ -13,12 +13,14 @@
 - (NSRect) originalRectOfRow:(NSInteger) row;
 @end
 
-@interface NSObject (MVTableViewDataSource)
+@protocol MVTableViewDataSource <NSTableViewDataSource>
+@optional
 - (NSMenu *) tableView:(MVTableView *) view menuForTableColumn:(NSTableColumn *) column row:(NSInteger) row;
 - (NSString *) tableView:(MVTableView *) view toolTipForTableColumn:(NSTableColumn *) column row:(NSInteger) row;
 @end
 
-@interface NSObject (MVTableViewDelegate)
+@protocol MVTableViewDelegate <NSTableViewDelegate>
+@optional
 - (void) clear:(id) sender;
 - (NSRect) tableView:(MVTableView *) tableView rectOfRow:(NSInteger) row defaultRect:(NSRect) defaultRect;
 - (NSRange) tableView:(MVTableView *) tableView rowsInRect:(NSRect) rect defaultRange:(NSRange) defaultRange;

--- a/main.m
+++ b/main.m
@@ -1,7 +1,7 @@
-#import <libxml/globals.h>
-#import <libxml/parser.h>
-#import <libxslt/xslt.h>
-#import <libexslt/exslt.h>
+#include <libxml/globals.h>
+#include <libxml/parser.h>
+#include <libxslt/xslt.h>
+#include <libexslt/exslt.h>
 
 int main( int count, const char *arg[] ) {
 	srandom( (unsigned int)time( NULL ) );


### PR DESCRIPTION
Include C headers, import Objective-C.
For some odd reason, `-[JVChatRoomMember menu]` command used `-stringWithUTF8String:` instead of `NSString` constants.
`JVStyle`'s `-baseLocation` and `-mainStyleSheetLocation` went through an unnecessary construction to `NSURL`: `NSBundle` has had `NSURL` methods since 10.6.