### PR TITLE
Add a preference to open links in SFSafariViewController or Chrome

### DIFF
--- a/Mobile/Controllers/CQColloquyApplication.m
+++ b/Mobile/Controllers/CQColloquyApplication.m
@@ -609,29 +609,23 @@ NSString *CQColloquyApplicationDidRecieveDeviceTokenNotification = @"CQColloquyA
 		NSString *openLinksIn = [[NSUserDefaults standardUserDefaults] stringForKey:@"CQOpenLinksIn"];
 
 		if ([openLinksIn isEqualToString:@"Safari"]) {
-				[super openURL:url];
+			[super openURL:url];
 		} else if ([openLinksIn isEqualToString:@"Chrome"]) {
 			NSString *scheme = url.scheme;
-			
-			// Replace the URL Scheme with the Chrome equivalent.
+
+			// Match HTTP(s) with the Chrome equivalent
 			NSString *chromeScheme = nil;
 			if ([scheme caseInsensitiveCompare:@"http"] == NSOrderedSame) {
 				chromeScheme = @"googlechrome";
 			} else if ([scheme caseInsensitiveCompare:@"https"] == NSOrderedSame) {
 				chromeScheme = @"googlechromes";
 			}
-			
-			// Proceed only if a valid Google Chrome URI Scheme is available.
-			if (chromeScheme) {
-				NSString *absoluteString = [url absoluteString];
-				NSRange rangeForScheme = [absoluteString rangeOfString:@":"];
-				NSString *urlNoScheme =
-				[absoluteString substringFromIndex:rangeForScheme.location];
-				NSString *chromeURLString =
-				[chromeScheme stringByAppendingString:urlNoScheme];
-				NSURL *chromeURL = [NSURL URLWithString:chromeURLString];
-				
-				// Open the URL with Chrome.
+
+			if (chromeScheme.length) {
+				NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+				components.scheme = chromeScheme;
+
+				NSURL *chromeURL = components.url;
 				if ([self canOpenURL:chromeURL]) {
 					[super openURL:chromeURL];
 				} else {
@@ -641,8 +635,8 @@ NSString *CQColloquyApplicationDidRecieveDeviceTokenNotification = @"CQColloquyA
 				[super openURL:url];
 			}
 		} else {
-			SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:url];
-			[[self window].rootViewController presentViewController:safari animated:YES completion:nil];
+			SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
+			[self.window.rootViewController presentViewController:safariViewController animated:YES completion:nil];
 		}
 	}
 

--- a/Mobile/Controllers/CQColloquyApplication.m
+++ b/Mobile/Controllers/CQColloquyApplication.m
@@ -615,9 +615,9 @@ NSString *CQColloquyApplicationDidRecieveDeviceTokenNotification = @"CQColloquyA
 			
 			// Replace the URL Scheme with the Chrome equivalent.
 			NSString *chromeScheme = nil;
-			if ([scheme isEqualToString:@"http"]) {
+			if ([scheme caseInsensitiveCompare:@"http"] == NSOrderedSame) {
 				chromeScheme = @"googlechrome";
-			} else if ([scheme isEqualToString:@"https"]) {
+			} else if ([scheme caseInsensitiveCompare:@"https"] == NSOrderedSame) {
 				chromeScheme = @"googlechromes";
 			}
 			
@@ -637,6 +637,8 @@ NSString *CQColloquyApplicationDidRecieveDeviceTokenNotification = @"CQColloquyA
 				} else {
 					[super openURL:[NSURL URLWithString:@"itms-apps://itunes.apple.com/us/app/chrome/id535886823"]];
 				}
+			} else {
+				[super openURL:url];
 			}
 		} else {
 			SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:url];

--- a/Mobile/Resources/Info.plist
+++ b/Mobile/Resources/Info.plist
@@ -44,6 +44,13 @@
 	<string>source</string>
 	<key>CQBuildType</key>
 	<string>personal</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>org-appextension-feature-password-management</string>
+		<string>googlechrome</string>
+		<string>googlechromes</string>
+		<string>itms-apps</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MVChatCoreCTCPVersionReplyInfo</key>
@@ -75,10 +82,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-	</array>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>org-appextension-feature-password-management</string>
 	</array>
 </dict>
 </plist>

--- a/Mobile/Resources/Settings.bundle/Root.plist
+++ b/Mobile/Resources/Settings.bundle/Root.plist
@@ -188,11 +188,25 @@
 		</dict>
 		<dict>
 			<key>Type</key>
-			<string>PSChildPaneSpecifier</string>
+			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
-			<string>Advanced Behavior</string>
-			<key>File</key>
-			<string>AdvancedBehavior</string>
+			<string>Open Links In</string>
+			<key>Key</key>
+			<string>CQOpenLinksIn</string>
+			<key>DefaultValue</key>
+			<string>In-App</string>
+			<key>Values</key>
+			<array>
+				<string>In-App</string>
+				<string>Safari</string>
+				<string>Chrome</string>
+			</array>
+			<key>Titles</key>
+			<array>
+				<string>In-App Browser</string>
+				<string>Safari</string>
+				<string>Chrome</string>
+			</array>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/Mobile/Resources/Settings.bundle/Root.plist
+++ b/Mobile/Resources/Settings.bundle/Root.plist
@@ -210,6 +210,14 @@
 		</dict>
 		<dict>
 			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+			<key>Title</key>
+			<string>Advanced Behavior</string>
+			<key>File</key>
+			<string>AdvancedBehavior</string>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>
 		<dict>


### PR DESCRIPTION
In iOS 9 Apple introduced the SFSafariViewController and it's since spread to become the default way to open a link from inside your app. This PR implements that for Colloquy mobile, makes it the default, and allows users to switch back to the old behavior of calling openURL instead.

The PR also goes a step further allowing users to open their links in Chrome if installed, and if they choose to do that and Chrome is not installed, it will send them to the App Store to install Chrome.

I am not much of an iOS developer but I _think_ I did a decent job here. Hope to get some constructive feedback though.

![simulator screen shot - iphone x - 2017-11-25 at 14 13 28](https://user-images.githubusercontent.com/57629/33234394-c62853da-d1eb-11e7-9249-e5aaefeb6cf2.png)
![simulator screen shot - iphone x - 2017-11-25 at 14 13 45](https://user-images.githubusercontent.com/57629/33234395-c84be4c4-d1eb-11e7-928f-0d0dd6490bd5.png)
![simulator screen shot - iphone x - 2017-11-25 at 14 17 53](https://user-images.githubusercontent.com/57629/33234396-ca3107d8-d1eb-11e7-9388-6a9958f9e536.png)
