### PR TITLE
Export symbols

### DIFF
--- a/Mac-Old/Mac-Old/Plug-Ins/AppleScript Support/JVAppleScriptPluginLoader.h
+++ b/Mac-Old/Mac-Old/Plug-Ins/AppleScript Support/JVAppleScriptPluginLoader.h
@@ -1,5 +1,6 @@
 #import "MVChatPluginManager.h"
 
+COLLOQUY_EXPORT
 @interface JVAppleScriptPluginLoader : NSObject <MVChatPlugin> {
 	MVChatPluginManager *_manager;
 }

--- a/Mac-Old/Mac-Old/Plug-Ins/F-Script Support/JVFScriptPluginLoader.h
+++ b/Mac-Old/Mac-Old/Plug-Ins/F-Script Support/JVFScriptPluginLoader.h
@@ -1,5 +1,6 @@
 #import "MVChatPluginManager.h"
 
+COLLOQUY_EXPORT
 @interface JVFScriptPluginLoader : NSObject <MVChatPlugin> {
 	MVChatPluginManager *_manager;
 	BOOL _fscriptInstalled;

--- a/Mac-Old/Mac-Old/Plug-Ins/JavaScript Support/JVJavaScriptPluginLoader.h
+++ b/Mac-Old/Mac-Old/Plug-Ins/JavaScript Support/JVJavaScriptPluginLoader.h
@@ -1,5 +1,6 @@
 #import "MVChatPluginManager.h"
 
+COLLOQUY_EXPORT
 @interface JVJavaScriptPluginLoader : NSObject <MVChatPlugin> {
 	MVChatPluginManager *_manager;
 }

--- a/Mac-Old/Mac-Old/Plug-Ins/Python Support/JVPythonPluginLoader.h
+++ b/Mac-Old/Mac-Old/Plug-Ins/Python Support/JVPythonPluginLoader.h
@@ -1,5 +1,6 @@
 #import "MVChatPluginManager.h"
 
+COLLOQUY_EXPORT
 @interface JVPythonPluginLoader : NSObject <MVChatPlugin> {
 	MVChatPluginManager *_manager;
 	BOOL _pyobjcInstalled;

--- a/Mac-Old/MetadataImporter/main.c
+++ b/Mac-Old/MetadataImporter/main.c
@@ -25,7 +25,7 @@ typedef struct __MetadataImporterPluginType
 MetadataImporterPluginType  *AllocMetadataImporterPluginType(CFUUIDRef inFactoryID);
 void                      DeallocMetadataImporterPluginType(MetadataImporterPluginType *thisInstance);
 HRESULT                   MetadataImporterQueryInterface(void *thisInstance,REFIID iid,LPVOID *ppv);
-void                     *MetadataImporterPluginFactory(CFAllocatorRef allocator,CFUUIDRef typeID);
+COLLOQUY_EXPORT void      *MetadataImporterPluginFactory(CFAllocatorRef allocator,CFUUIDRef typeID);
 ULONG                     MetadataImporterPluginAddRef(void *thisInstance);
 ULONG                     MetadataImporterPluginRelease(void *thisInstance);
 

--- a/Mac-Old/StandardCommands/JVStandardCommands.h
+++ b/Mac-Old/StandardCommands/JVStandardCommands.h
@@ -3,6 +3,7 @@
 @class MVChatConnection;
 @protocol JVChatViewController;
 
+COLLOQUY_EXPORT
 @interface JVStandardCommands : NSObject <MVChatPlugin>
 - (BOOL) handleFileSendWithArguments:(NSString *) arguments forConnection:(MVChatConnection *) connection;
 - (BOOL) handleCTCPWithArguments:(NSString *) arguments forConnection:(MVChatConnection *) connection;


### PR DESCRIPTION
This marks some symbols with `COLLOQUY_EXPORT`, which makes them visible outside of their binary object.

The metadata plug-in is probably the most affected, but exporting the others doesn't hurt, either.