### PR TITLE
Have the metadata plug-in build NSDateAdditions.

### DIFF
--- a/Colloquy (Old).xcodeproj/project.pbxproj
+++ b/Colloquy (Old).xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		1CF8030F070C893500C9B54C /* libsilcclient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CF8030D070C893500C9B54C /* libsilcclient.framework */; };
 		1CF80310070C894100C9B54C /* libsilc.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 1CF8030C070C893500C9B54C /* libsilc.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1CF80311070C894100C9B54C /* libsilcclient.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 1CF8030D070C893500C9B54C /* libsilcclient.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		55F7D7D22127844100CED413 /* NSDateAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9220565D11018298005CD72D /* NSDateAdditions.m */; };
 		891E8467123F0AEF00EC3C0F /* NSCharacterSetAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 891E8466123F0AEF00EC3C0F /* NSCharacterSetAdditions.m */; };
 		891EF3D1106426CB00CCEA35 /* PFMoveApplicationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 891EF3D0106426CB00CCEA35 /* PFMoveApplicationController.m */; };
 		9200338D13D92515005B69BA /* MVFileTransfer.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9200338B13D92515005B69BA /* MVFileTransfer.xib */; };
@@ -1980,6 +1981,7 @@
 			files = (
 				CBF6856208201B7A00F498FB /* GetMetadataForFile.m in Sources */,
 				CBF6856308201B7A00F498FB /* main.c in Sources */,
+				55F7D7D22127844100CED413 /* NSDateAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Commits 146772c5a97bc9df4138025688db42ea3261d77a and 63d02dc5527ae035de6b702ad3e5ff383b927ba7 replace the deprecation usage of `-[NSDate initWithString:]` in the Spotlight plug-in with a method from NSDateAdditions.m. Problem is, the Spotlight plug-in doesn't build the file, leading to "unrecognized selector sent to instance" errors when attempting to load files into Spotlight. This patch fixes that.